### PR TITLE
Add excludeStaticFields builder option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ Search for "Builderberg" and install the plugin.
 ##### BuilderConstraint Annotations
 If you're looking to leverage the power of BuilderConstraints (notNull, notEmpty, notBlank, notNull, notNegative, etc.), BuilderOptions (deserializable, minimumPluginVersion, exceptionType, generateClone, etc.), or CustomLogic you'll need to include the builderberg-annotations module in your projects.
 Using gradle:
-* compileOnly group: 'com.github.davidburkett', name: 'builderberg-annotations', version: '1.1.2'
+* compileOnly group: 'com.github.davidburkett', name: 'builderberg-annotations', version: '1.1.3'
 
 ## Usage
 

--- a/builderberg-annotations/build.gradle
+++ b/builderberg-annotations/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'signing'
 
 group = 'com.github.davidburkett'
 archivesBaseName = 'builderberg-annotations'
-version = '1.1.2'
+version = '1.1.3'
 ext.packaging = 'jar'
 
 

--- a/builderberg-annotations/src/main/java/com/github/davidburkett/builderberg/annotations/BuilderOptions.java
+++ b/builderberg-annotations/src/main/java/com/github/davidburkett/builderberg/annotations/BuilderOptions.java
@@ -61,4 +61,12 @@ public @interface BuilderOptions {
      * @return {@code true} if collections for generated objects should be made immutable.
      */
     boolean makeCollectionsImmutable() default false;
+
+    /**
+     * Excludes static fields from getter, hashCode, equals, and toString methods. This behavior is preferred but is
+     * disabled by default to avoid breaking existing consumers.
+     *
+     * @since 1.1.3
+     */
+    boolean excludeStaticFields() default false;
 }

--- a/builderberg-plugin/build.gradle
+++ b/builderberg-plugin/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'signing'
 
 group = 'com.github.davidburkett'
 archivesBaseName = 'builderberg-plugin'
-version = '1.2.1'
+version = '1.2.2'
 ext.packaging = 'jar'
 
 repositories {
@@ -53,6 +53,6 @@ intellij {
 }
 patchPluginXml {
     changeNotes """
-    - Update hashCode generation locic to take into account Enum members. Java does not guarantee the same hashCode for the same value for different sessions.
+    - Add excludeStaticFields builder option to exclude static fields from getter, hashCode, equals, and toString methods.
     """
 }

--- a/builderberg-plugin/src/main/java/com/github/davidburkett/builderberg/generators/EqualsGenerator.java
+++ b/builderberg-plugin/src/main/java/com/github/davidburkett/builderberg/generators/EqualsGenerator.java
@@ -1,6 +1,7 @@
 package com.github.davidburkett.builderberg.generators;
 
 import com.github.davidburkett.builderberg.utilities.AnnotationUtility;
+import com.github.davidburkett.builderberg.utilities.BuilderOptionUtility;
 import com.github.davidburkett.builderberg.utilities.MethodUtility;
 import com.github.davidburkett.builderberg.utilities.TypeUtility;
 import com.google.common.collect.ImmutableList;
@@ -49,8 +50,15 @@ public class EqualsGenerator {
         // Add type casting
         methodUtility.addStatement(equalsMethod, String.format("final %s obj = (%s) o;", typeName, typeName));
 
+        // Check if excludeStaticFields is enabled
+        final boolean excludeStaticFields = BuilderOptionUtility.excludeStaticFields(topLevelClass);
+
         // Add comparison for each field
         for (final PsiField field : topLevelClass.getFields()) {
+            if (excludeStaticFields && field.hasModifierProperty(PsiModifier.STATIC)) {
+                continue;
+            }
+
             generateFieldComparison(equalsMethod, field);
         }
 

--- a/builderberg-plugin/src/main/java/com/github/davidburkett/builderberg/generators/GetterGenerator.java
+++ b/builderberg-plugin/src/main/java/com/github/davidburkett/builderberg/generators/GetterGenerator.java
@@ -1,10 +1,7 @@
 package com.github.davidburkett.builderberg.generators;
 
 import com.github.davidburkett.builderberg.utilities.*;
-import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiElementFactory;
-import com.intellij.psi.PsiField;
-import com.intellij.psi.PsiMethod;
+import com.intellij.psi.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,8 +17,14 @@ public class GetterGenerator {
     }
 
     public void generateGetters(final PsiClass topLevelClass) {
+        final boolean excludeStaticFields = BuilderOptionUtility.excludeStaticFields(topLevelClass);
+
         final List<PsiField> fields = Arrays.asList(topLevelClass.getFields());
         for (PsiField field : fields) {
+            if (excludeStaticFields && field.hasModifierProperty(PsiModifier.STATIC)) {
+                continue;
+            }
+
             final String getterMethodName = MethodNameUtility.getGetterName(field);
             generateGetter(topLevelClass, field, getterMethodName);
 

--- a/builderberg-plugin/src/main/java/com/github/davidburkett/builderberg/generators/ToStringGenerator.java
+++ b/builderberg-plugin/src/main/java/com/github/davidburkett/builderberg/generators/ToStringGenerator.java
@@ -1,6 +1,7 @@
 package com.github.davidburkett.builderberg.generators;
 
 import com.github.davidburkett.builderberg.utilities.AnnotationUtility;
+import com.github.davidburkett.builderberg.utilities.BuilderOptionUtility;
 import com.github.davidburkett.builderberg.utilities.MethodUtility;
 import com.google.common.collect.ImmutableList;
 import com.intellij.psi.*;
@@ -35,16 +36,26 @@ public class ToStringGenerator {
     }
 
     private void addReturnStatement(final PsiClass topLevelClass, final PsiMethod toStringMethod) {
+        final boolean excludeStaticFields = BuilderOptionUtility.excludeStaticFields(topLevelClass);
+
         // Generate string value
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("\"{");
         final PsiField[] fields = topLevelClass.getFields();
+        boolean includedField = false;
         for (int i = 0; i < fields.length; i++) {
-            if (i != 0) {
-                stringBuilder.append(",");
+            final PsiField field = fields[i];
+
+            if (excludeStaticFields && field.hasModifierProperty(PsiModifier.STATIC)) {
+                continue;
             }
 
-            final PsiField field = fields[i];
+            if (includedField) {
+                stringBuilder.append(",");
+            } else {
+                includedField = true;
+            }
+
             stringBuilder.append(createStringForField(field));
         }
         stringBuilder.append("}\"");

--- a/builderberg-plugin/src/main/java/com/github/davidburkett/builderberg/utilities/BuilderOptionUtility.java
+++ b/builderberg-plugin/src/main/java/com/github/davidburkett/builderberg/utilities/BuilderOptionUtility.java
@@ -115,6 +115,18 @@ public class BuilderOptionUtility {
         return false;
     }
 
+    public static boolean excludeStaticFields(final PsiClass topLevelClass) {
+        final PsiAnnotationMemberValue value = getBuilderOption(topLevelClass, "excludeStaticFields");
+        if (value != null) {
+            final String text = value.getText();
+            if (text != null && text.equals("true")) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private static PsiAnnotationMemberValue getBuilderOption(final PsiClass topLevelClass, final String attributeName) {
         final Optional<PsiAnnotation> psiAnnotationOptional = AnnotationUtility.getBuilderOptionsAnnotation(topLevelClass);
 


### PR DESCRIPTION
Add excludeStaticFields builder option to exclude static fields from getter, hashCode, equals, and toString methods.